### PR TITLE
Add missing Unity Input module reference

### DIFF
--- a/CoiStatsBridge.csproj
+++ b/CoiStatsBridge.csproj
@@ -47,6 +47,10 @@
       <HintPath>$(COI_MANAGED)\UnityEngine.IMGUIModule.dll</HintPath>
       <Private>false</Private>
     </Reference>
+    <Reference Include="UnityEngine.InputLegacyModule">
+      <HintPath>$(COI_MANAGED)\UnityEngine.InputLegacyModule.dll</HintPath>
+      <Private>false</Private>
+    </Reference>
 
     <!-- BCL extras used by Unity/COI -->
     <Reference Include="System.Net.Http">


### PR DESCRIPTION
## Summary
- Reference UnityEngine.InputLegacyModule to fix compilation errors involving Input class

## Testing
- `dotnet build -p:COI_MANAGED=/tmp` *(fails: COI_MANAGED is wrong: '/tmp'. Could not find Mafi.Core.dll)*

------
https://chatgpt.com/codex/tasks/task_e_68b4dc114ff483308d837d136d11c1f7