### PR TITLE
Add F9 debug overlay toggle

### DIFF
--- a/DebugState.cs
+++ b/DebugState.cs
@@ -8,5 +8,6 @@ namespace CoiStatsBridge
     public static string Method   = "not bound";
     public static int    Products = 0;
     public static string LastPostUtc = "-";
+    public static long   Tick = 0;
   }
 }

--- a/StatsBridgeMb.cs
+++ b/StatsBridgeMb.cs
@@ -24,6 +24,7 @@ namespace CoiStatsBridge
       var snapshot = TypedSnapshotReader.Read();
       var ts = NowMs();
       var payload = JsonWriter.BuildPayload(ts, _tick, snapshot);
+      DebugState.Tick = _tick;
       _tick++;
 
       try

--- a/StatsOverlayMb.cs
+++ b/StatsOverlayMb.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Linq;
 using UnityEngine;
+#if ENABLE_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+#endif
 
 namespace CoiStatsBridge
 {
@@ -8,12 +11,15 @@ namespace CoiStatsBridge
   {
     const int _winId = unchecked((int)0xC01ABEEF);
     Rect _rect = new Rect(32, 32, 420, 280);
-    bool _show = true;
+    bool _show = false;
     Vector2 _scroll;
 
     void Update()
     {
       if (Input.GetKeyDown(KeyCode.F9)) _show = !_show;
+#if ENABLE_INPUT_SYSTEM
+      if (Keyboard.current != null && Keyboard.current.f9Key.wasPressedThisFrame) _show = !_show;
+#endif
     }
 
     void OnGUI()
@@ -29,6 +35,7 @@ namespace CoiStatsBridge
       GUILayout.Label($"method:   {DebugState.Method}");
       GUILayout.Label($"products: {DebugState.Products}");
       GUILayout.Label($"last post (UTC): {DebugState.LastPostUtc}");
+      GUILayout.Label($"tick:     {DebugState.Tick}");
 
       GUILayout.Space(6);
       GUILayout.Label("Preview (top 15 by qty):");


### PR DESCRIPTION
## Summary
- allow toggling debug overlay with F9 using both legacy and new input systems
- display current tick in overlay
- track tick in DebugState for diagnostics

## Testing
- `dotnet build` *(fails: COI_MANAGED is not set)*
- `dotnet build -p:COI_MANAGED=/tmp/Managed` *(fails: Could not find Mafi.Core.dll)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e0f495ec8330a059fa63b23d64ff