### PR TITLE
Ensure stats overlay attaches and toggles on F9

### DIFF
--- a/CoiStatsBridgeStartup.cs
+++ b/CoiStatsBridgeStartup.cs
@@ -23,15 +23,18 @@ namespace CoiStatsBridge
     {
       const string GO_NAME = "CoiStatsBridgeGO";
       var go = GameObject.Find(GO_NAME);
-      if (go != null) return;
+      if (go == null)
+      {
+        go = new GameObject(GO_NAME);
+        Object.DontDestroyOnLoad(go);
+      }
 
-      go = new GameObject(GO_NAME);
-      Object.DontDestroyOnLoad(go);
+      bool addedBridge = false, addedOverlay = false;
+      if (go.GetComponent<StatsBridgeMb>() == null) { go.AddComponent<StatsBridgeMb>(); addedBridge = true; }
+      if (go.GetComponent<StatsOverlayMb>() == null) { go.AddComponent<StatsOverlayMb>(); addedOverlay = true; }
 
-      if (go.GetComponent<StatsBridgeMb>() == null) go.AddComponent<StatsBridgeMb>();
-      if (go.GetComponent<StatsOverlayMb>() == null) go.AddComponent<StatsOverlayMb>();
-
-      CoiLogger.Info("Attached StatsBridgeMb + StatsOverlayMb");
+      if (addedBridge || addedOverlay)
+        CoiLogger.Info("Attached StatsBridgeMb + StatsOverlayMb");
     }
   }
 }

--- a/StatsOverlayMb.cs
+++ b/StatsOverlayMb.cs
@@ -6,7 +6,8 @@ namespace CoiStatsBridge
   public sealed class StatsOverlayMb : MonoBehaviour
   {
     Rect _rect = new Rect(40, 40, 360, 220);
-    bool _show = true;
+    // Start hidden so F9 explicitly toggles visibility
+    bool _show = false;
     int  _winId;
 
     GUIStyle _win, _label, _small;
@@ -15,15 +16,17 @@ namespace CoiStatsBridge
     void Awake()
     {
       _winId = ("CoiStatsBridge.Window".GetHashCode() ^ 0x5A5A5A5A);
+      CoiLogger.Info("StatsOverlayMb awake");
     }
 
     void Update()
     {
-      // F9 primary; Alt+F9 fallback
-      if (Input.GetKeyDown(KeyCode.F9) || (Input.GetKey(KeyCode.LeftAlt) && Input.GetKeyDown(KeyCode.F9)))
+      // F9 primary; Alt+F9 fallback (if the game intercepts F9 alone)
+      bool alt = Input.GetKey(KeyCode.LeftAlt) || Input.GetKey(KeyCode.RightAlt);
+      if (Input.GetKeyDown(KeyCode.F9))
       {
         _show = !_show;
-        CoiLogger.Info($"F9 pressed. Overlay now {(_show ? "visible" : "hidden")}");
+        CoiLogger.Info($"F9{(alt ? " (Alt)" : "")} pressed. Overlay now {(_show ? "visible" : "hidden")}");
       }
     }
 


### PR DESCRIPTION
## Summary
- Ensure startup attaches overlay and bridge components even if the GameObject already exists
- Add debug log on overlay awake and start hidden; toggle visibility on F9 press

## Testing
- `dotnet build` *(fails: COI_MANAGED is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68b5db1b8b188330b57a0f2fb0463105